### PR TITLE
Register resourcePath onLoad, not onAttach

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1,4 +1,4 @@
-.onAttach <- function(...) {
+.onLoad <- function(...) {
   
   # Create link to javascript and css files for package
   shiny::addResourcePath("sbs", system.file("www", package="shinyBS"))


### PR DESCRIPTION
This allows to use shinyBS using the `::` syntax, without
requiring to load the package.